### PR TITLE
Prefetch data

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -47,7 +47,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "300kb",
-                  "maximumError": "325kb"
+                  "maximumError": "330kb"
                 },
                 {
                   "type": "anyComponentStyle",
@@ -58,7 +58,7 @@
                   "type": "bundle",
                   "name": "main",
                   "maximumWarning": "300kb",
-                  "maximumError": "317kb"
+                  "maximumError": "320kb"
                 },
                 {
                   "type": "bundle",

--- a/projects/movies/src/app/app-shell/app-shell.component.ts
+++ b/projects/movies/src/app/app-shell/app-shell.component.ts
@@ -16,7 +16,6 @@ import { StateService } from '../shared/state/state.service';
   providers: [RxState]
 })
 export class AppShellComponent {
-
   constructor(
     private state: RxState<{
       activeRoute: string;

--- a/projects/movies/src/app/app-shell/app-shell.component.ts
+++ b/projects/movies/src/app/app-shell/app-shell.component.ts
@@ -16,13 +16,14 @@ import { StateService } from '../shared/state/state.service';
   providers: [RxState]
 })
 export class AppShellComponent {
+
   constructor(
     private state: RxState<{
       activeRoute: string;
       loggedIn: boolean;
       sideDrawerOpen: boolean;
     }>,
-    public tmdbState: StateService,
+    public globalState: StateService,
     public authState: AuthStateService,
     public authEffects: TmdbAuthEffects,
     private router: Router
@@ -43,6 +44,7 @@ export class AppShellComponent {
         map((e) => e.urlAfterRedirects.split('?')[0])
       )
     );
+    this.init();
     /**
      * **🚀 Perf Tip for TBT:**
      *
@@ -51,7 +53,11 @@ export class AppShellComponent {
     setTimeout(() => this.router.navigate([]));
   }
 
-  genres$ = this.tmdbState.genresNames$;
+  init() {
+    this.globalState.refreshGenres();
+  }
+
+  genres$ = this.globalState.genresNames$;
   @ViewChild('snav') snav: any;
 
   readonly viewState$ = this.state.select();

--- a/projects/movies/src/app/shared/state/state.service.ts
+++ b/projects/movies/src/app/shared/state/state.service.ts
@@ -1,16 +1,24 @@
 import { Injectable } from '@angular/core';
-import { exhaustMap, filter, map, Observable, Subject } from 'rxjs';
+import { catchError, exhaustMap, filter, map, Observable, startWith, Subject, switchMap, withLatestFrom } from 'rxjs';
 import { Tmdb2Service } from '../../data-access/api/tmdb2.service';
 import { MovieGenreModel } from '../../data-access/model/movie-genre.model';
 import { MovieModel } from '../../data-access/model/movie.model';
-import { patch, RxState, selectSlice } from '@rx-angular/state';
+import { patch, RxState, select, selectSlice } from '@rx-angular/state';
 import { optimizedFetch } from '../utils/optimized-fetch';
 import { parseTitle } from '../utils/parse-movie-list-title';
+import { NavigationEnd, Router } from '@angular/router';
+
+type RouterParams = {
+  type: 'genre' | 'category';
+  identifier: string;
+};
 
 interface State {
   genres: MovieGenreModel[];
   genreMovies: Record<string, MovieModel[]>;
+  genreMoviesContext: boolean;
   categoryMovies: Record<string, MovieModel[]>;
+  categoryMoviesContext: boolean;
 }
 
 interface Command<T extends commandNames, P = any> {
@@ -19,6 +27,7 @@ interface Command<T extends commandNames, P = any> {
 }
 
 export interface MovieList {
+  loading: boolean;
   title: string;
   movies: MovieModel[];
 }
@@ -36,29 +45,54 @@ type commands = refreshGenres | fetchCategoryMovies | fetchGenreMovies;
 export class StateService extends RxState<State> {
   private commands = new Subject<commands>();
 
+  private routerParams$: Observable<RouterParams> = this.router.events
+    .pipe(
+      select(
+        filter(event => event instanceof NavigationEnd),
+        map(_ => {
+          const [__, page, type, identifier] = this.router.routerState.snapshot.url.split('/');
+          return { page, type, identifier };
+        }),
+        selectSlice(['identifier', 'type'])
+      )
+    ) as unknown as Observable<RouterParams>;
+  routerGenre$ = this.routerParams$.pipe(filter(({ type }) => type === 'genre'), map(({ identifier }) => identifier));
+  routerCategory$ = this.routerParams$.pipe(filter(({ type }) => type === 'category'), map(({ identifier }) => identifier));
+
   genresNames$ = this.select('genres');
-  genreMovieList$ = (genreParam: number | string): Observable<MovieList> => this.select(
-    selectSlice(['genres', 'genreMovies']),
-    map(({ genres, genreMovies }) => {
-      const genreIdStr = genreParam as string;
+  genreMovieList$ = this.select(
+    selectSlice(['genres', 'genreMovies', 'genreMoviesContext']),
+    withLatestFrom(this.routerGenre$),
+    map(([{ genres, genreMovies, genreMoviesContext }, genreParam]) => {
+      const genreIdStr = genreParam as unknown as string;
       const genreId = parseInt(genreIdStr, 10);
       const genreName = genres.find((g: MovieGenreModel) => g.id === genreId)?.name || 'unknown genre';
       return {
+        loading: genreMoviesContext,
         title: parseTitle(genreName),
         movies: genreMovies && genreMovies[genreIdStr] || []
       };
     })
   );
 
-  categoryMovieList$ = (listName: string): Observable<MovieList> => this.select(
-    map(({ categoryMovies }) => ({
-      title: parseTitle(listName),
-      movies: categoryMovies && categoryMovies[listName] || []
-    }))
+  categoryMovieList$: Observable<MovieList> = this.select(
+    selectSlice(['categoryMovies', 'categoryMoviesContext']),
+    withLatestFrom(this.routerCategory$),
+    map(([{ categoryMovies, categoryMoviesContext }, listName]) => {
+        return ({
+          loading: categoryMoviesContext,
+          title: parseTitle(listName),
+          movies: categoryMovies && categoryMovies[listName] || []
+        });
+      }
+    )
   );
 
+  routedMovieList$ = this.routerParams$.pipe(
+    switchMap(({ type }) => type === 'genre' ? this.genreMovieList$ : this.categoryMovieList$)
+  );
 
-  constructor(private tmdb2Service: Tmdb2Service) {
+  constructor(private tmdb2Service: Tmdb2Service, private router: Router) {
     super();
     this.connect('genres', this.commands.pipe(
       filter(({ type }) => type === 'refreshGenres'),
@@ -72,7 +106,6 @@ export class StateService extends RxState<State> {
     );
 
     this.connect(
-      'categoryMovies',
       this.commands.pipe(
         filter(({ type }) => type === 'fetchCategoryMovies'),
         /**
@@ -83,15 +116,22 @@ export class StateService extends RxState<State> {
         optimizedFetch(
           ({ payload: category }) => 'category' + '-' + category,
           ({ payload: category }) => this.tmdb2Service.getMovieCategory(category)
-            .pipe(map(({ results }) => ({ [category]: results }))))
+            .pipe(
+              map(({ results }) => ({ categoryMoviesContext: false, categoryMovies: { [category]: results } })),
+              startWith({ categoryMoviesContext: true }),
+              catchError(_ => ([{ categoryMoviesContext: true }]))
+            )
+        )
       ),
-      ({ categoryMovies }, newPartial) => {
-        return patch(categoryMovies, newPartial);
+      (oldState, newPartial) => {
+        let s = newPartial as unknown as State;
+        let resultState = patch(oldState, s);
+        resultState.categoryMovies = patch(oldState?.categoryMovies, resultState.categoryMovies);
+        return resultState;
       }
     );
 
     this.connect(
-      'genreMovies',
       this.commands.pipe(
         filter(({ type }) => type === 'fetchGenreMovies'),
         /**
@@ -102,14 +142,27 @@ export class StateService extends RxState<State> {
         optimizedFetch(
           ({ payload: genre }) => 'genre' + '-' + genre,
           ({ payload: genre }) => this.tmdb2Service.getMovieGenre(genre)
-            .pipe(map(({ results }) => ({ [genre]: results }))))
+            .pipe(
+              map(({ results }) => ({ genreMoviesContext: false, genreMovies: { [genre]: results } })),
+              startWith({ genreMoviesContext: true }),
+              catchError(_ => ([{ genreMoviesContext: true }]))
+            )
+        )
       ),
-      ({ genreMovies }, newPartial) => patch(genreMovies, newPartial)
+      (oldState, newPartial) => {
+        let s = newPartial as unknown as State;
+        let resultState = patch(oldState, s);
+        resultState.genreMovies = patch(oldState.genreMovies, resultState.genreMovies);
+        return resultState;
+      }
     );
+
+    this.hold(this.routerParams$, this.routerFetchEffect);
   }
 
   init(): void {
     this.refreshGenres();
+    this.fetchCategoryMovies('popular');
   }
 
   refreshGenres(): void {
@@ -123,4 +176,13 @@ export class StateService extends RxState<State> {
   fetchGenreMovies(genre: string | number): void {
     this.commands.next({ type: 'fetchGenreMovies', payload: genre });
   }
+
+  private routerFetchEffect = ({ type, identifier }: RouterParams) => {
+    if (type === 'category') {
+      this.fetchCategoryMovies(identifier);
+    } else if (type === 'genre') {
+      this.fetchGenreMovies(identifier);
+    }
+  };
+
 }


### PR DESCRIPTION
To Improve LCP i prefetch the sidebar data and the default routes data from the server.

Following things got implemented:
- moved the loading state into the global state
- moved router into global state
- implemented init for default route
  - sidenav data **-53ms**
  - LCP relevant data **-160ms**

![Reduce TBT  chunk up bootstrap work](https://user-images.githubusercontent.com/10064416/144781727-9d5d15e1-7c3f-4ce4-82ba-ef90fe4364ab.png)
![Reduce TBT  chunk up bootstrap work (1)](https://user-images.githubusercontent.com/10064416/144781734-f1775087-b15e-4363-8e5c-8ebc0a8b95f6.png)

