### PR TITLE
fix(): define srcset in adapter

### DIFF
--- a/projects/movies/src/app/pages/account-feature/account-list-page/account-list-page.component.html
+++ b/projects/movies/src/app/pages/account-feature/account-list-page/account-list-page.component.html
@@ -22,7 +22,7 @@
         <img
           class="aspectRatio-16-9 gradient"
           [ngSrc]="list.imgSrc"
-          [ngSrcset]="'154w, 185w'"
+          [ngSrcset]="'154w, 185w, 342w, 500w, 780w'"
           [width]="list.imgWidth"
           [height]="list.imgHeight"
           [alt]="list.name"

--- a/projects/movies/src/app/pages/account-feature/list-detail-page/list-detail-page.adapter.ts
+++ b/projects/movies/src/app/pages/account-feature/list-detail-page/list-detail-page.adapter.ts
@@ -44,6 +44,8 @@ export class ListDetailAdapter extends RxState<{
   private readonly routerState = inject(RouterState);
   readonly ui = new RxActionFactory<Actions>().create();
 
+  readonly srcset = '154w, 185w, 342w, 500w, 780w';
+
   readonly routerListId$ = this.routerState.select(map((state) => state?.type));
 
   private readonly listInfoUpdateEvent$ = this.ui.listInfoUpdate$.pipe(

--- a/projects/movies/src/app/pages/account-feature/list-detail-page/list-image/list-image.component.html
+++ b/projects/movies/src/app/pages/account-feature/list-detail-page/list-image/list-image.component.html
@@ -18,6 +18,7 @@
     <img
       class="aspectRatio-4-3 gradient"
       [ngSrc]="movie.imgSrc"
+      [ngSrcset]="adapter.srcset"
       width="355"
       height="200"
       alt="poster movie"

--- a/projects/movies/src/app/pages/account-feature/list-detail-page/list-items-edit/list-items-edit.adapter.ts
+++ b/projects/movies/src/app/pages/account-feature/list-detail-page/list-items-edit/list-items-edit.adapter.ts
@@ -38,6 +38,8 @@ export class ListItemsEditAdapter extends RxState<{
   private moviesResource = inject(MovieResource);
   readonly ui = new RxActionFactory<Actions>().create();
 
+  readonly srcset = '92w, 154w, 185w, 342w, 500w, 780w';
+
   readonly vm$ = this.select(
     selectSlice(['items', 'searchResults', 'showResults', 'searchValue']),
     map(({ items, searchResults, showResults, searchValue }) => ({

--- a/projects/movies/src/app/pages/account-feature/list-detail-page/list-items-edit/list-items-edit.component.html
+++ b/projects/movies/src/app/pages/account-feature/list-detail-page/list-items-edit/list-items-edit.component.html
@@ -23,6 +23,7 @@
           <img
             class="result-image gradient"
             [ngSrc]="movie.imgSrc"
+            [ngSrcset]="adapter.srcset"
             [width]="movie.imgWidth"
             [height]="movie.imgHeight"
             alt="poster movie"


### PR DESCRIPTION
When user navigates from lists to specific list movie.imgSrcset works as expected, but in case of reload it is empty and falls back to default x2,x3,x4.

Don't know the exact reason of the bug, but decent fix will be to have srcset property definied on adapter level since all images on the page should have same set.